### PR TITLE
Add optional support for CmdS3Copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## 0.2.1 - 2019-03-22
+- Add optional support for CmdS3Copy operation.

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="shrub.py",
-    version="0.2.0",
+    version="0.2.1",
     description="Library for creating evergreen configurations",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/src/shrub/operations.py
+++ b/src/shrub/operations.py
@@ -574,6 +574,7 @@ class CmdS3Copy(EvergreenCommand):
         self._aws_key = None
         self._aws_secret = None
         self._files = []
+        self._optional = None
 
     def _command_type(self):
         return "s3Copy.copy"
@@ -585,6 +586,7 @@ class CmdS3Copy(EvergreenCommand):
         return {
             "_aws_key": "aws_key",
             "_aws_secret": "aws_secret",
+            "_optional": "optional",
         }
 
     def _export_params(self):
@@ -608,6 +610,10 @@ class CmdS3Copy(EvergreenCommand):
 
     def files(self, files):
         self._files += files
+        return self
+
+    def optional(self):
+        self._optional = True
         return self
 
 

--- a/tests/shrub/test_operations.py
+++ b/tests/shrub/test_operations.py
@@ -592,10 +592,27 @@ class TestCmdS3Copy:
         p = params(c)
         assert "aws key" == p["aws_key"]
         assert "aws secret" == p["aws_secret"]
+        assert "optional" not in p
         assert "bucket 0" == p["s3_copy_files"][0]["source"]["bucket"]
         assert "path 0" == p["s3_copy_files"][0]["source"]["path"]
         assert "bucket 3" == p["s3_copy_files"][1]["destination"]["bucket"]
         assert "path 3" == p["s3_copy_files"][1]["destination"]["path"]
+
+    def test_optional_parameter(self):
+        c = CmdS3Copy()
+        f0 = AwsCopyFile() \
+            .display_name("f0 name") \
+            .source("bucket 0", "path 0") \
+            .destination("bucket 1", "path 1")
+        f1 = AwsCopyFile() \
+            .display_name("f1 name") \
+            .source("bucket 2", "path 2") \
+            .destination("bucket 3", "path 3")
+        c.aws_key("aws key").optional().aws_secret("aws secret")\
+            .file(f0).files([f1])
+
+        p = params(c)
+        assert p["optional"]
 
 
 class TestCmdGetProject:

--- a/tests/shrub/test_operations.py
+++ b/tests/shrub/test_operations.py
@@ -608,10 +608,11 @@ class TestCmdS3Copy:
             .display_name("f1 name") \
             .source("bucket 2", "path 2") \
             .destination("bucket 3", "path 3")
-        c.aws_key("aws key").optional().aws_secret("aws secret")\
-            .file(f0).files([f1])
+        c.aws_key("aws key").aws_secret("aws secret")\
+            .file(f0).files([f1]).optional()
 
         p = params(c)
+        assert "optional" in p
         assert p["optional"]
 
 


### PR DESCRIPTION
This feature is needed for some of the work I'm doing to convert all resmoke tasks to use generate.tasks.