### PR TITLE
EVG-8450: fix exec timeout secs key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.1.1 - 2020-09-16
+- Fix a bug where 'exec_timeout_secs' set the wrong key.
+
 ## 1.1.0 - 2020-05-08
 * Add python 3.6 support.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "shrub.py"
-version = "1.1.0"
+version = "1.1.1"
 description = "Library for creating evergreen configurations"
 authors = [
     "David Bradford <david.bradford@mongodb.com>",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ packages = [
 [tool.poetry.dependencies]
 python = "^3.6"
 PyYaml = "^5.1"
-dataclasses = {version = "^0.7", python = "3.6"}
+dataclasses = {version = "^0.7", python = "3.6.*"}
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.3"

--- a/src/shrub/config.py
+++ b/src/shrub/config.py
@@ -45,7 +45,7 @@ class Configuration(EvergreenBuilder):
             "_pre": {NAME_KEY: "pre", RECURSE_KEY: True},
             "_post": {NAME_KEY: "post", RECURSE_KEY: True},
             "_timeout": {NAME_KEY: "timeout", RECURSE_KEY: False},
-            "_exec_timeout_secs": {NAME_KEY: "timeout", RECURSE_KEY: False},
+            "_exec_timeout_secs": {NAME_KEY: "exec_timeout_secs", RECURSE_KEY: False},
             "_batch_time_secs": {NAME_KEY: "batchtime", RECURSE_KEY: False},
             "_stepback": {NAME_KEY: "stepback", RECURSE_KEY: False},
             "_command_type": {NAME_KEY: "command_type", RECURSE_KEY: False},

--- a/tests/shrub/test_config.py
+++ b/tests/shrub/test_config.py
@@ -18,7 +18,7 @@ class TestConfiguration:
 
         obj = c.to_map()
 
-        assert obj["timeout"] == 20
+        assert obj["exec_timeout_secs"] == 20
         assert obj["batchtime"] == 300
         assert "file1" in obj["ignore"]
         assert "file2" in obj["ignore"]


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-8450

Set `exec_timeout_secs` field instead of `timeout`.