### PR TITLE
EVG-14310: Add ability to set "activate" value for tasks.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "shrub.py"
-version = "3.0.4"
+version = "3.0.5"
 description = "Library for creating evergreen configurations"
 authors = [
     "David Bradford <david.bradford@mongodb.com>",

--- a/src/shrub/base.py
+++ b/src/shrub/base.py
@@ -23,7 +23,10 @@ class EvergreenBuilder(abc.ABC):
     def _add_if_defined(self, obj, prop):
         """Add the specified property to the given object if it exists."""
         value = getattr(self, prop)
-        if value:
+
+        # We can't just use the falsiness of value because false is a value
+        # with semantic meaning different from undefined in some keys.
+        if value is not None and value != [] and value != {}:
             if self._yaml_map()[prop][RECURSE_KEY]:
                 if isinstance(value, collections.abc.Sequence):
                     value = [v.to_map() for v in value]

--- a/src/shrub/task.py
+++ b/src/shrub/task.py
@@ -17,6 +17,7 @@ class Task(EvergreenBuilder):
         self._dependencies = []
         self._requires = []
         self._commands = CommandSequence()
+        self._activate = None
 
     def _yaml_map(self):
         return {
@@ -25,6 +26,7 @@ class Task(EvergreenBuilder):
             "_priority": {NAME_KEY: "priority", RECURSE_KEY: False},
             "_dependencies": {NAME_KEY: "depends_on", RECURSE_KEY: True},
             "_requires": {NAME_KEY: "requires", RECURSE_KEY: True},
+            "_activate": {NAME_KEY: "activate", RECURSE_KEY: False},
         }
 
     def get_name(self):
@@ -142,6 +144,19 @@ class Task(EvergreenBuilder):
             raise TypeError("function_with_vars only accepts a dict")
 
         self._commands.add(CommandDefinition().function(fn).vars(var_map))
+        return self
+
+    def activate(self, activate):
+        """
+        Specify whether this task should be activated.
+
+        :param activate: whether to activate this task.
+        :return: instance of task spec.
+        """
+        if not isinstance(activate, bool) and activate is not None:
+            raise TypeError("activate only accepts a bool or None")
+
+        self._activate = activate
         return self
 
 

--- a/src/shrub/variant.py
+++ b/src/shrub/variant.py
@@ -23,6 +23,7 @@ class Variant(EvergreenBuilder):
         self._expansions = {}
         self._display_task_specs = []
         self._modules = []
+        self._activate = []
 
     def _yaml_map(self):
         return {
@@ -34,6 +35,7 @@ class Variant(EvergreenBuilder):
             "_expansions": {NAME_KEY: "expansions", RECURSE_KEY: False},
             "_display_task_specs": {NAME_KEY: "display_tasks", RECURSE_KEY: True},
             "_modules": {NAME_KEY: "modules", RECURSE_KEY: False},
+            "_activate": {NAME_KEY: "activate", RECURSE_KEY: False},
         }
 
     def get_name(self):
@@ -195,6 +197,19 @@ class Variant(EvergreenBuilder):
 
         return self
 
+    def activate(self, activate):
+        """
+        Specify whether the tasks in this variant should be activated.
+
+        :param activate: whether to activate tasks in this variant.
+        :return: instance of task spec.
+        """
+        if not isinstance(activate, bool) and activate is not None:
+            raise TypeError("activate only accepts a bool or None")
+
+        self._activate = activate
+        return self
+
 
 class TaskSpec(EvergreenBuilder):
     """A spec for adding a task to a variant."""
@@ -208,12 +223,14 @@ class TaskSpec(EvergreenBuilder):
         self._name = name
         self._stepback = None
         self._distro = []
+        self._activate = None
 
     def _yaml_map(self):
         return {
             "_name": {NAME_KEY: "name", RECURSE_KEY: False},
             "_stepback": {NAME_KEY: "stepback", RECURSE_KEY: False},
             "_distro": {NAME_KEY: "distros", RECURSE_KEY: False},
+            "_activate": {NAME_KEY: "activate", RECURSE_KEY: False},
         }
 
     def stepback(self):
@@ -235,6 +252,19 @@ class TaskSpec(EvergreenBuilder):
             raise TypeError("distro only accepts a str")
 
         self._distro = [distro]
+        return self
+
+    def activate(self, activate):
+        """
+        Specify whether this task should be activated.
+
+        :param activate: whether to activate this task.
+        :return: instance of task spec.
+        """
+        if not isinstance(activate, bool) and activate is not None:
+            raise TypeError("activate only accepts a bool or None")
+
+        self._activate = activate
         return self
 
 

--- a/tests/shrub/test_task.py
+++ b/tests/shrub/test_task.py
@@ -119,6 +119,23 @@ class TestTask:
         with pytest.raises(TypeError):
             Task(42)
 
+    def test_task_activate(self):
+        t = Task("task name")
+        obj = t.to_map()
+        assert "activate" not in obj
+
+        t.activate(True)
+        obj = t.to_map()
+        assert obj["activate"] is True
+
+        t.activate(False)
+        obj = t.to_map()
+        assert obj["activate"] is False
+
+        t.activate(None)
+        obj = t.to_map()
+        assert "activate" not in obj
+
 
 class TestTaskDependency:
     def test_flat_values(self):

--- a/tests/shrub/test_variant.py
+++ b/tests/shrub/test_variant.py
@@ -125,6 +125,23 @@ class TestVariant:
         with pytest.raises(TypeError):
             v.display_tasks("hello world")
 
+    def test_variant_activate(self):
+        v = Variant("variant name")
+        obj = v.to_map()
+        assert "activate" not in obj
+
+        v.activate(True)
+        obj = v.to_map()
+        assert obj["activate"] is True
+
+        v.activate(False)
+        obj = v.to_map()
+        assert obj["activate"] is False
+
+        v.activate(None)
+        obj = v.to_map()
+        assert "activate" not in obj
+
 
 class TestTaskSpec:
     def test_task_spec(self):
@@ -134,6 +151,23 @@ class TestTaskSpec:
         assert "task name" == obj["name"]
         assert obj["stepback"]
         assert ["linux"] == obj["distros"]
+
+    def test_task_spec_activate(self):
+        ts = TaskSpec("task name")
+        obj = ts.to_map()
+        assert "activate" not in obj
+
+        ts.activate(True)
+        obj = ts.to_map()
+        assert obj["activate"] is True
+
+        ts.activate(False)
+        obj = ts.to_map()
+        assert obj["activate"] is False
+
+        ts.activate(None)
+        obj = ts.to_map()
+        assert "activate" not in obj
 
     def test_invalid_distro(self):
         ts = TaskSpec("task name")


### PR DESCRIPTION
This value was introduced a couple of years ago, and we need to update the v1 version of shrub.py so that Genny can generate tasks that don't auto activate.

Note that undefined/null is different from both true and false for activate, since in a task if activate is undefined it will try to get the setting from the variant. Because of this, there are some code changes to make sure this setting works properly if set to any of null, false, or true.