### PR TITLE
Update README example to v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.1.5 - 2024-10-07
+- Updated README example to use v3 API
+
 ## 3.1.4 - 2024-09-30
 - Added command for generating github tokens
 

--- a/README.md
+++ b/README.md
@@ -15,30 +15,37 @@ building Evergreen project configurations described [here](https://github.com/ev
 The following snippet will create a set of parallel tasks reported under a single display task. It
 would generate json used by ```generate.tasks```:
 
-```
-from shrub.v2 import ShrubProject, Task, BuildVariant
+```python
+from shrub.v3.evg_task import EvgTask, EvgTaskDependency
+from shrub.v3.evg_build_variant import BuildVariant, DisplayTask
+from shrub.v3.evg_command import FunctionCall
+from shrub.v3.evg_project import EvgProject
+from shrub.v3.shrub_service import ShrubService
+
 
 n_tasks = 10
 def define_task(index):
     name = f"task_name_{index}"
 
-    return Task(
-        name,
-        [
-            FunctionCall("do setup"),
+    return EvgTask(
+        name=name,
+        commands=[
+            FunctionCall(func="do setup"),
             FunctionCall(
-                "run test generator",
-                {"parameter_1": "value 1", "parameter_2": "value 2"}
+                func="run test generator",
+                vars={"parameter_1": "value 1", "parameter_2": "value 2"}
             ),
-            FunctionCall("run tests")
+            FunctionCall(func="run tests")
         ],
-    ).dependency("compile")
+        depends_on=[EvgTaskDependency(name="compile")]
+    )
 
-tasks = {define_task(i) for i in range(n_tasks)}
-variant = BuildVariant("linux-64").display_task("test_suite", tasks)
-project = ShrubProject({variant})
+tasks = [define_task(i) for i in range(n_tasks)]
+display_task = DisplayTask(name="test_suite", execution_tasks=[t.name for t in tasks])
+variant = BuildVariant(name="linux-64", tasks=[], display_tasks=[display_task])
+project = EvgProject(buildvariants=[variant], tasks=tasks)
 
-project.json()
+print(ShrubService.generate_json(project))
 ```
 
 ## Run tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "shrub.py"
-version = "3.1.4"
+version = "3.1.5"
 description = "Library for creating evergreen configurations"
 authors = ["DevProd Services & Integrations Team <devprod-si-team@mongodb.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
Howdy!  We're looking to adopt `shrub.py` for `mongo-python-driver` and I figured I start by contributing back!  If you'd rather I include both v2 and v3 examples I can do that as well, but it looked like v2 is considered to be legacy at this point.