### PR TITLE
Add custom yaml output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.1.6 - 2024-10-08
+- Added custom yaml output for `shrub.v3.shrub_service.generate_yaml`.
+
 ## 3.1.5 - 2024-10-07
 - Updated README example to use v3 API
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 3.1.6 - 2024-10-08
+## 3.2.0 - 2024-10-09
 - Added custom yaml output for `shrub.v3.shrub_service.ShrubService.generate_yaml`
 
 ## 3.1.5 - 2024-10-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 3.1.6 - 2024-10-08
-- Added custom yaml output for `shrub.v3.shrub_service.generate_yaml`.
+- Added custom yaml output for `shrub.v3.shrub_service.ShrubService.generate_yaml`.
 
 ## 3.1.5 - 2024-10-07
 - Updated README example to use v3 API

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 3.1.6 - 2024-10-08
-- Added custom yaml output for `shrub.v3.shrub_service.ShrubService.generate_yaml`.
+- Added custom yaml output for `shrub.v3.shrub_service.ShrubService.generate_yaml`
 
 ## 3.1.5 - 2024-10-07
 - Updated README example to use v3 API

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "shrub.py"
-version = "3.1.6"
+version = "3.2.0"
 description = "Library for creating evergreen configurations"
 authors = ["DevProd Services & Integrations Team <devprod-si-team@mongodb.com>"]
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "shrub.py"
-version = "3.1.5"
+version = "3.1.6"
 description = "Library for creating evergreen configurations"
 authors = ["DevProd Services & Integrations Team <devprod-si-team@mongodb.com>"]
 license = "Apache-2.0"

--- a/src/shrub/v3/shrub_service.py
+++ b/src/shrub/v3/shrub_service.py
@@ -75,15 +75,15 @@ class ConfigDumper(yaml.SafeDumper):
 
         return node
 
+    # Represent updates mapping for expansions.update commands using flow
+    # style to reduce line count:
+    #    - command: expansions.update
+    #      params:
+    #        updates:
+    #          - { key: KEY, value: VALUE }
+    #          - { key: KEY, value: VALUE }
+    #          - { key: KEY, value: VALUE }
     def represent_mapping(self, tag, mapping, flow_style=False):
-        # Represent updates mapping for expansions.update commands using flow
-        # style to reduce line count:
-        #    - command: expansions.update
-        #      params:
-        #        updates:
-        #          - { key: KEY, value: VALUE }
-        #          - { key: KEY, value: VALUE }
-        #          - { key: KEY, value: VALUE }
         if len(mapping) == 2 and "key" in mapping and "value" in mapping:
             flow_style = True
 

--- a/src/shrub/v3/shrub_service.py
+++ b/src/shrub/v3/shrub_service.py
@@ -75,8 +75,6 @@ class ConfigDumper(yaml.SafeDumper):
 
         return node
 
-    # Make an effort to order fields in a readable manner.
-    # Ordering applies to *all* mappings regardless of the parent node.
     def represent_mapping(self, tag, mapping, flow_style=False):
         # Represent updates mapping for expansions.update commands using flow
         # style to reduce line count:

--- a/src/shrub/v3/shrub_service.py
+++ b/src/shrub/v3/shrub_service.py
@@ -1,6 +1,130 @@
 """Service for working with shrub."""
+
 import yaml
 from pydantic import BaseModel
+
+
+class ConfigDumper(yaml.SafeDumper):
+    # Represent multiline strings in the form:
+    #     key: |
+    #       multiline string
+    #       multiline string
+    #       multiline string
+    def represent_scalar(self, tag, value, style=None):
+        if isinstance(value, str) and "\n" in value:
+            style = "|"
+        return super().represent_scalar(tag, value, style)
+
+    # Prefer using double quotes when able.
+    def analyze_scalar(self, scalar):
+        res = super().analyze_scalar(scalar)
+        if res.allow_single_quoted and res.allow_double_quoted:
+            res.allow_single_quoted = False
+        return res
+
+    # Represent flow mappings with space after left brace:
+    #     node: { key: value }
+    #            ^
+    def expect_flow_mapping(self):
+        super().expect_flow_mapping()
+        self.write_indicator("", False)
+
+    # Represent flow mappings with space before right brace:
+    #     node: { key: value }
+    #                       ^
+    def expect_flow_mapping_key(self):
+        if isinstance(self.event, yaml.MappingEndEvent):
+            self.write_indicator(" ", False)
+        super().expect_flow_mapping_key()
+
+    # Allow for special-casing depending on parent node.
+    def represent_special_mapping(self, tag, mapping, flow_style):
+        value = []
+
+        for item_key, item_value in mapping:
+            node_key = self.represent_data(item_key)
+
+            if item_key == "tags":
+                # Represent task tags using flow style to reduce line count:
+                #     - name: task-name
+                #       tags: [A, B, C]
+                node_value = self.represent_sequence(
+                    "tag:yaml.org,2002:seq", item_value, flow_style=True
+                )
+            elif item_key == "depends_on" and len(item_value) == 1:
+                # Represent task depends_on using flow style when only one
+                # dependency is given to reduce line count:
+                #     - name: task-name
+                #       depends_on: [{ name: dependency }]
+                node_value = self.represent_sequence(
+                    "tag:yaml.org,2002:seq", item_value, flow_style=True
+                )
+            else:
+                # Use default behavior.
+                node_value = self.represent_data(item_value)
+
+            value.append((node_key, node_value))
+
+        node = yaml.MappingNode(tag, value, flow_style=flow_style)
+
+        if self.alias_key is not None:
+            self.represented_objects[self.alias_key] = node
+
+        return node
+
+    # Make an effort to order fields in a readable manner.
+    # Ordering applies to *all* mappings regardless of the parent node.
+    def represent_mapping(self, tag, mapping, flow_style=False):
+        # Represent updates mapping for expansions.update commands using flow
+        # style to reduce line count:
+        #    - command: expansions.update
+        #      params:
+        #        updates:
+        #          - { key: KEY, value: VALUE }
+        #          - { key: KEY, value: VALUE }
+        #          - { key: KEY, value: VALUE }
+        if len(mapping) == 2 and "key" in mapping and "value" in mapping:
+            flow_style = True
+
+        before = [
+            "name",
+            "display_name",
+            "command",
+            "type",
+            "run_on",
+            "tags",
+            "depends_on",
+            "binary",
+            "working_dir",
+        ]
+
+        after = [
+            "commands",
+            "args",
+        ]
+
+        ordered = {field: mapping.pop(field) for field in before if field in mapping}
+
+        suffix = {field: mapping.pop(field) for field in after if field in mapping}
+
+        ordered.update(sorted(mapping.items()))
+        ordered.update(suffix)
+
+        return self.represent_special_mapping(tag, ordered.items(), flow_style)
+
+    # Ensure a block sequence is indented relative to its parent node::
+    #     key:
+    #       - a
+    #       - b
+    #       - c
+    # instead of::
+    #     key:
+    #     - a
+    #     - b
+    #     - c
+    def increase_indent(self, flow=None, indentless=None):
+        indentless = False
+        return super().increase_indent(flow=flow, indentless=indentless)
 
 
 class ShrubService:
@@ -14,8 +138,11 @@ class ShrubService:
         :param shrub_config: Shrub configuration to generate.
         :return: YAML version of given shrub configuration.
         """
-        return yaml.safe_dump(
-            shrub_config.dict(exclude_none=True, exclude_unset=True, by_alias=True)
+        return yaml.dump(
+            shrub_config.dict(exclude_none=True, exclude_unset=True, by_alias=True),
+            Dumper=ConfigDumper,
+            default_flow_style=False,
+            width=float("inf"),
         )
 
     @staticmethod

--- a/tests/shrub/v3/test_shrub_service.py
+++ b/tests/shrub/v3/test_shrub_service.py
@@ -3,6 +3,8 @@
 import json
 import pytest
 
+from pydantic import BaseModel, ConfigDict
+from yaml.representer import RepresenterError
 from shrub.v3.evg_task import EvgTask, EvgTaskDependency
 from shrub.v3.evg_build_variant import BuildVariant, DisplayTask
 from shrub.v3.evg_command import FunctionCall, shell_exec, subprocess_exec
@@ -120,3 +122,18 @@ def test_project_yaml(project):
     assert EXPECTED_YAML1 in out
     assert EXPECTED_YAML2 in out
     assert EXPECTED_YAML3 in out
+
+
+class CustomClass:
+    pass
+
+
+class UnsafeModel(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+    prop: CustomClass
+
+
+def test_safe_yaml():
+    model = UnsafeModel(prop=CustomClass(), arbitrary_types_allowed=True)
+    with pytest.raises(RepresenterError):
+        ShrubService.generate_yaml(model)

--- a/tests/shrub/v3/test_shrub_service.py
+++ b/tests/shrub/v3/test_shrub_service.py
@@ -114,6 +114,7 @@ EXPECTED_YAML3 = """
   - name: task_name_5
 """
 
+
 def test_project_yaml(project):
     out = ShrubService.generate_yaml(project)
     assert EXPECTED_YAML1 in out

--- a/tests/shrub/v3/test_shrub_service.py
+++ b/tests/shrub/v3/test_shrub_service.py
@@ -1,0 +1,78 @@
+"""Unit tests for shrub_service.py."""
+
+import json
+import pytest
+
+from shrub.v3.evg_task import EvgTask, EvgTaskDependency
+from shrub.v3.evg_build_variant import BuildVariant, DisplayTask
+from shrub.v3.evg_command import FunctionCall
+from shrub.v3.evg_project import EvgProject
+from shrub.v3.shrub_service import ShrubService
+
+
+@pytest.fixture
+def project():
+    n_tasks = 10
+
+    def define_task(index):
+        name = f"task_name_{index}"
+
+        return EvgTask(
+            name=name,
+            commands=[
+                FunctionCall(func="do setup"),
+                FunctionCall(
+                    func="run test generator",
+                    vars={"parameter_1": "value 1", "parameter_2": "value 2"},
+                ),
+                FunctionCall(func="run tests"),
+            ],
+            depends_on=[EvgTaskDependency(name="compile")],
+        )
+
+    tasks = [define_task(i) for i in range(n_tasks)]
+    display_task = DisplayTask(name="test_suite", execution_tasks=[t.name for t in tasks])
+    variant = BuildVariant(name="linux-64", tasks=[], display_tasks=[display_task])
+    return EvgProject(buildvariants=[variant], tasks=tasks)
+
+
+def test_project_json(project):
+    out = ShrubService.generate_json(project)
+    data = json.loads(out)
+    assert "buildvariants" in data
+    assert "tasks" in data
+
+
+EXPECTED_YAML = """
+buildvariants:
+  - name: linux-64
+    display_tasks:
+      - name: test_suite
+        execution_tasks:
+          - task_name_0
+          - task_name_1
+          - task_name_2
+          - task_name_3
+          - task_name_4
+          - task_name_5
+          - task_name_6
+          - task_name_7
+          - task_name_8
+          - task_name_9
+    tasks: []
+tasks:
+  - name: task_name_0
+    depends_on: [{ name: compile }]
+    commands:
+      - func: do setup
+      - func: run test generator
+        vars:
+          parameter_1: value 1
+          parameter_2: value 2
+      - func: run tests
+""".strip()
+
+
+def test_project_yaml(project):
+    out = ShrubService.generate_yaml(project)
+    assert EXPECTED_YAML in out, out


### PR DESCRIPTION
Adds the `ConfigDumper` class from [`mongo-c-driver`](https://github.com/mongodb/mongo-c-driver/blob/b3c006d2ce0a91a6c48e10cd592a3a43deb5373f/.evergreen/config_generator/etc/utils.py#L91).  The output more closely matches what we use in our hand written config. 
