### PR TITLE
Add support for task fields: run_on, disable, and batchtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.3.0 - 2024-10-10
+- Added `run_on`, `batchtime`, and `patchable` fields to `shrub.v3.evg_task.EvgTask`
+
 ## 3.2.0 - 2024-10-09
 - Added custom yaml output for `shrub.v3.shrub_service.ShrubService.generate_yaml`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "shrub.py"
-version = "3.2.0"
+version = "3.3.0"
 description = "Library for creating evergreen configurations"
 authors = ["DevProd Services & Integrations Team <devprod-si-team@mongodb.com>"]
 license = "Apache-2.0"

--- a/src/shrub/v3/evg_task.py
+++ b/src/shrub/v3/evg_task.py
@@ -1,5 +1,5 @@
 """Evergreen models for tasks."""
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from pydantic import BaseModel
 
@@ -37,18 +37,24 @@ class EvgTask(BaseModel):
     * name: Name of task.
     * commands: List of commands that make up task.
     * depends_on: Other tasks that must be successful for this task to run.
+    * run_on: Distros this task should be run on.
     * exec_timeout_secs: Time task can run before being considered timing out.
     * tags: List of tags to attach to task.
+    * disable: Prevent this task from running at all.
     * patchable: Whether this task can run in patch builds.
+    * batchtime: How frequent this task should be run.
     * stepback: Whether this task should run stepback.
     """
 
     name: str
     commands: Optional[List[EvgCommand]] = None
     depends_on: Optional[List[EvgTaskDependency]] = None
+    run_on: Optional[Union[str, List[str]]] = None
     exec_timeout_secs: Optional[int] = None
     tags: Optional[List[str]] = None
+    disable: Optional[bool] = None
     patchable: Optional[bool] = None
+    batchtime: Optional[int] = None
     stepback: Optional[bool] = None
 
     def get_task_ref(self, distros: Optional[List[str]] = None) -> EvgTaskRef:

--- a/tests/shrub/v3/test_evg_task.py
+++ b/tests/shrub/v3/test_evg_task.py
@@ -1,0 +1,161 @@
+from shrub.v3.evg_project import EvgProject
+from shrub.v3.evg_task import EvgTask, EvgTaskDependency
+from shrub.v3.shrub_service import ShrubService
+from shrub.v3.evg_command import FunctionCall, subprocess_exec
+
+
+def _test_task_field(field, value, content):
+    # Test both implicit and explicit `None`.
+    if value is None:
+        assert content is None
+
+        task = EvgTask(name="test task")
+        out = ShrubService.generate_yaml(EvgProject(tasks=[task], buildvariants=[]))
+        assert field not in out
+
+        args = {field: value}
+        task = EvgTask(name="test task", **args)
+        out = ShrubService.generate_yaml(EvgProject(tasks=[task], buildvariants=[]))
+        assert field not in out
+
+    # Test presence of expected values.
+    else:
+        args = {field: value}
+        task = EvgTask(name="test task", **args)
+        out = ShrubService.generate_yaml(EvgProject(tasks=[task], buildvariants=[]))
+
+        for value in content:
+            assert value in out
+
+
+class TestTaskFields:
+    def test_task_name(self):
+        task = EvgTask(name="task name")
+        out = ShrubService.generate_yaml(EvgProject(tasks=[task], buildvariants=[]))
+        assert "task name" in out
+
+    def test_task_commands(out):
+        _test_task_field("commands", None, None)
+        _test_task_field("commands", [], ["commands: []"])
+
+        _test_task_field(
+            "commands",
+            [FunctionCall(func="func")],
+            [
+                "commands:",
+                "func: func",
+            ],
+        )
+
+        _test_task_field(
+            "commands",
+            [subprocess_exec(binary="binary")],
+            [
+                "commands:",
+                "command: subprocess.exec",
+                "binary: binary",
+            ],
+        )
+
+        _test_task_field(
+            "commands",
+            [FunctionCall(func="one"), FunctionCall(func="two")],
+            [
+                "commands:",
+                "func: one",
+                "func: two",
+            ],
+        )
+
+    def test_task_depends_on(self):
+        _test_task_field("depends_on", None, None)
+        _test_task_field("depends_on", [], ["depends_on: []"])
+
+        _test_task_field(
+            "depends_on",
+            [EvgTaskDependency(name="task")],
+            [
+                "depends_on:",
+                "name: task",
+            ],
+        )
+
+        _test_task_field(
+            "depends_on",
+            [EvgTaskDependency(name="one"), EvgTaskDependency(name="two")],
+            [
+                "depends_on:",
+                "name: one",
+                "name: two",
+            ],
+        )
+
+    def test_task_run_on(self):
+        _test_task_field("run_on", None, None)
+        _test_task_field("run_on", [], ["run_on: []"])
+        _test_task_field("run_on", str(), ['run_on: ""'])
+        _test_task_field("run_on", "distro name", ["run_on: distro name"])
+
+        _test_task_field(
+            "run_on",
+            ["distro name"],
+            [
+                "run_on:",
+                "- distro name",
+            ],
+        )
+
+        _test_task_field(
+            "run_on",
+            ["one", "two"],
+            [
+                "run_on:",
+                "- one",
+                "- two",
+            ],
+        )
+
+    def test_task_exec_timeout_secs(self):
+        _test_task_field("exec_timeout_secs", None, None)
+        _test_task_field("exec_timeout_secs", 0, ["exec_timeout_secs: 0"])
+        _test_task_field("exec_timeout_secs", 123, ["exec_timeout_secs: 123"])
+
+    def test_task_tags(self):
+        _test_task_field("tags", None, None)
+        _test_task_field("tags", [], "tags: []")
+        _test_task_field("tags", ["tag"], "tags: [tag]")
+        _test_task_field("tags", ["one", "two"], "tags: [one, two]")
+        _test_task_field("tags", ["one", "two", "three"], "tags: [one, two, three]")
+
+        # See `ConfigDumper.FLOW_TAG_COUNT` in src/shrub/v3/shrub_service.py.
+        _test_task_field(
+            "tags",
+            ["one", "two", "three", "four"],
+            [
+                "tags:",
+                "- one",
+                "- two",
+                "- three",
+                "- four",
+            ],
+        )
+
+    def test_task_disable(self):
+        _test_task_field("disable", None, None)
+        _test_task_field("disable", False, "disable: false")
+        _test_task_field("disable", True, "disable: true")
+
+    def test_task_patchable(self):
+        _test_task_field("patchable", None, None)
+        _test_task_field("patchable", False, ["patchable: false"])
+        _test_task_field("patchable", True, ["patchable: true"])
+
+    def test_task_batchtime(self):
+        _test_task_field("batchtime", None, None)
+        _test_task_field("batchtime", 0, ["batchtime: 0"])
+        _test_task_field("batchtime", 123, ["batchtime: 123"])
+
+    def test_task_stepback(self):
+        _test_task_field("stepback", None, None)
+        _test_task_field("stepback", False, ["stepback: false"])
+        _test_task_field("stepback", True, ["stepback: true"])


### PR DESCRIPTION
Add support for task fields which are [supported by EVG](https://docs.devprod.prod.corp.mongodb.com/evergreen/Project-Configuration/Project-Configuration-Files) and currently being used by the [mongo-c-driver](https://github.com/mongodb/mongo-c-driver/blob/f5de26d30ce05eefab8a1b4c0f943b6d90509a87/.evergreen/config_generator/etc/utils.py#L19) but are not currently supported by the `EvgTask` class definition.

Documentation for the `run_on` and `batchtime` fields use their equivalents in the [BuildVariant](https://github.com/evergreen-ci/shrub.py/blob/f92b3e7e092e832d992341d8fa24258ef66eff27/src/shrub/v3/evg_build_variant.py#L21) class as reference.

The placement of the new fields relative to other fields in `EvgTask` is arbitrary. Please suggest an alternative ordering (i.e. alphabetic?) if preferable.

Unsure if `str | List[str]` is supported by shrub.py (Python 3.10 and newer), as no other instance of this pattern seems to be present in the repo at this time, so `Union[str, List[str]]` is used instead for consistency.