### PR TITLE
Make optional fields truly optional (pydantic 2.0 compatibility)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.3.1 - 2024-10-16
+- Added default value `None` to optional fields for pydantic 2.0 compatibility.
+
 ## 3.3.0 - 2024-10-10
 - Added `run_on`, `batchtime`, and `patchable` fields to `shrub.v3.evg_task.EvgTask`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "shrub.py"
-version = "3.3.0"
+version = "3.3.1"
 description = "Library for creating evergreen configurations"
 authors = ["DevProd Services & Integrations Team <devprod-si-team@mongodb.com>"]
 license = "Apache-2.0"

--- a/src/shrub/v3/evg_project.py
+++ b/src/shrub/v3/evg_project.py
@@ -25,7 +25,7 @@ class EvgParameter(BaseModel):
     """
 
     key: str
-    value: Optional[str]
+    value: Optional[str] = None
     description: str
 
 
@@ -75,8 +75,8 @@ class EvgProject(BaseModel):
     * parameters: Definition of available patch build parameters for the project.
     """
 
-    buildvariants: Optional[List[BuildVariant]]
-    tasks: Optional[List[EvgTask]]
+    buildvariants: Optional[List[BuildVariant]] = None
+    tasks: Optional[List[EvgTask]] = None
     functions: Optional[Dict[str, FunctionDefinition]] = None
     task_groups: Optional[List[EvgTaskGroup]] = None
     pre: Optional[List[EvgCommand]] = None


### PR DESCRIPTION
https://github.com/evergreen-ci/shrub.py/pull/33 added Pydantic 2.0 support but did not account for changes to `Optional` behavior, per the [Migration Guide](https://docs.pydantic.dev/2.9/migration/#required-optional-and-nullable-fields):

> Pydantic V2 changes some of the logic for specifying whether a field annotated as `Optional` is required (i.e., has no default value) or not (i.e., has a default value of `None` or any other value of the corresponding type), and now more closely matches the behavior of `dataclasses`.

The effect being that some optional fields that were not required with Pydantic 1.0 are now required with Pydantic 2.0 (even when the provided value is `None`). This PR restores true optionality by adding missing `= None` default values to optional fields. (Modules under shrub.v2 are ignored.)