### PR TITLE
Add additional "can fail" and "timeout" fields to task groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.4.0 - 2024-10-18
+- Added additional `*_can_fail_task` and `*_timeout_secs` fields to `shrub.v3.evg_task_group.EvgTaskGroup`.
+- Restrict the type of `*_timeout_secs` fields to `Optional[int]` instead of `Optional[Union[int, str]]`.
+
 ## 3.3.1 - 2024-10-16
 - Added default value `None` to optional fields for pydantic 2.0 compatibility.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 3.4.0 - 2024-10-18
+## 3.4.0 - 2024-10-30
 - Added additional `*_can_fail_task` and `*_timeout_secs` fields to `shrub.v3.evg_task_group.EvgTaskGroup`.
 - Restrict the type of `*_timeout_secs` fields to `Optional[int]` instead of `Optional[Union[int, str]]`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "shrub.py"
-version = "3.3.1"
+version = "3.4.0"
 description = "Library for creating evergreen configurations"
 authors = ["DevProd Services & Integrations Team <devprod-si-team@mongodb.com>"]
 license = "Apache-2.0"

--- a/src/shrub/v3/evg_task_group.py
+++ b/src/shrub/v3/evg_task_group.py
@@ -18,6 +18,7 @@ class EvgTaskGroup(BaseModel):
     * setup_group_can_fail_task: Whether a task group setup failure should make a task fail.
     * setup_group_timeout_secs: Time to wait until task group setup commands are stopped.
     * setup_group: List of commands to run before any task is run.
+    * teardown_group_timeout_secs: Time to wait until task group teardown commands are stopped.
     * teardown_group: List of commands to run after tasks finish on a host.
     * setup_task_can_fail_task: Whether a task setup failure should make a task fail.
     * setup_task_timeout_secs: Time to wait until setup commands are stopped.
@@ -37,6 +38,7 @@ class EvgTaskGroup(BaseModel):
     setup_group_timeout_secs: Optional[int] = None
     setup_group: Optional[List[EvgCommand]] = None
     # teardown_group_can_fail_task: Optional[int] = None # DEVPROD-12438
+    teardown_group_timeout_secs: Optional[int] = None
     teardown_group: Optional[List[EvgCommand]] = None
     setup_task_can_fail_task: Optional[bool] = None
     setup_task_timeout_secs: Optional[int] = None

--- a/src/shrub/v3/evg_task_group.py
+++ b/src/shrub/v3/evg_task_group.py
@@ -1,5 +1,5 @@
 """Evergreen configuration models for task groups."""
-from typing import List, Optional, Union
+from typing import List, Optional
 
 from pydantic import BaseModel
 
@@ -14,12 +14,16 @@ class EvgTaskGroup(BaseModel):
     * name: Name of task group.
     * tasks: List of tasks that belong to the task group.
     * max_hosts: Max number of hosts to run the tasks in the group on.
-    * share_processes: If True host is not cleaned up between task executions.
-    * setup_group_can_fail_task: Whether a setup failure should make a task fail.
-    * setup_group_timeout_secs: Time to wait until the setup in considered failed.
+    * share_processes: If true, host is not cleaned up between task executions.
+    * setup_group_can_fail_task: Whether a task group setup failure should make a task fail.
+    * setup_group_timeout_secs: Time to wait until task group setup commands are stopped.
     * setup_group: List of commands to run before any task is run.
     * teardown_group: List of commands to run after tasks finish on a host.
+    * setup_task_can_fail_task: Whether a task setup failure should make a task fail.
+    * setup_task_timeout_secs: Time to wait until setup commands are stopped.
     * setup_task: List of commands to run before a task is run.
+    * teardown_task_can_fail_task: Whether a task teardown failure should make a task fail.
+    * teardown_task_timeout_secs: Time to wait until teardown commands are stopped.
     * teardown_task: List of commands to run after a task is run.
     * timeout: List of commands to run when a timeout is encountered.
     * tags: Tags that should be applied to the task group.
@@ -30,10 +34,15 @@ class EvgTaskGroup(BaseModel):
     max_hosts: Optional[int] = None
     share_processes: Optional[bool] = None
     setup_group_can_fail_task: Optional[bool] = None
-    setup_group_timeout_secs: Optional[Union[int, str]] = None
+    setup_group_timeout_secs: Optional[int] = None
     setup_group: Optional[List[EvgCommand]] = None
+    teardown_group_can_fail_task: Optional[bool] = None
     teardown_group: Optional[List[EvgCommand]] = None
+    setup_task_can_fail_task: Optional[bool] = None
+    setup_task_timeout_secs: Optional[int] = None
     setup_task: Optional[List[EvgCommand]] = None
+    teardown_task_can_fail_task: Optional[bool] = None
+    teardown_task_timeout_secs: Optional[int] = None
     teardown_task: Optional[List[EvgCommand]] = None
     timeout: Optional[List[EvgCommand]] = None
     tags: Optional[List[str]] = None

--- a/src/shrub/v3/evg_task_group.py
+++ b/src/shrub/v3/evg_task_group.py
@@ -36,7 +36,7 @@ class EvgTaskGroup(BaseModel):
     setup_group_can_fail_task: Optional[bool] = None
     setup_group_timeout_secs: Optional[int] = None
     setup_group: Optional[List[EvgCommand]] = None
-    teardown_group_can_fail_task: Optional[bool] = None
+    # teardown_group_can_fail_task: Optional[int] = None # DEVPROD-12438
     teardown_group: Optional[List[EvgCommand]] = None
     setup_task_can_fail_task: Optional[bool] = None
     setup_task_timeout_secs: Optional[int] = None

--- a/src/shrub/v3/evg_task_group.py
+++ b/src/shrub/v3/evg_task_group.py
@@ -37,7 +37,6 @@ class EvgTaskGroup(BaseModel):
     setup_group_can_fail_task: Optional[bool] = None
     setup_group_timeout_secs: Optional[int] = None
     setup_group: Optional[List[EvgCommand]] = None
-    # teardown_group_can_fail_task: Optional[int] = None # DEVPROD-12438
     teardown_group_timeout_secs: Optional[int] = None
     teardown_group: Optional[List[EvgCommand]] = None
     setup_task_can_fail_task: Optional[bool] = None


### PR DESCRIPTION
Refer to the [Task Groups](https://docs.devprod.prod.corp.mongodb.com/evergreen/Project-Configuration/Project-Configuration-Files#task-groups) section of the "Project Configuration Files" page.

`evergreen validate` rejects a `*_timeout_secs` field of type `str`:

```yaml
task_groups:
  - name: example
    setup_group_timeout_secs: "123"
```
```
ERROR: load project error(s): loading file '[...]': error unmarshalling yaml strict: yaml: unmarshal errors:
  line 3: cannot unmarshal !!str `123` into int
```

The field types therefore updated from `Optional[Union[int, str]]` to `Optional[int]` accordingly.