### PR TITLE
Revert addition of task-level batchtime (DEVPROD-12032)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.3.2 - 2024-10-16
+- Revert support for `batchtime` field in `shrub.v3.evg_task.EvgTask`
+
 ## 3.3.1 - 2024-10-16
 - Added default value `None` to optional fields for pydantic 2.0 compatibility.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 3.3.2 - 2024-10-16
+## 3.3.2 - 2024-10-30
 - Revert support for `batchtime` field in `shrub.v3.evg_task.EvgTask`
 
 ## 3.3.1 - 2024-10-16

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "shrub.py"
-version = "3.3.1"
+version = "3.3.2"
 description = "Library for creating evergreen configurations"
 authors = ["DevProd Services & Integrations Team <devprod-si-team@mongodb.com>"]
 license = "Apache-2.0"

--- a/src/shrub/v3/evg_task.py
+++ b/src/shrub/v3/evg_task.py
@@ -54,7 +54,7 @@ class EvgTask(BaseModel):
     tags: Optional[List[str]] = None
     disable: Optional[bool] = None
     patchable: Optional[bool] = None
-    batchtime: Optional[int] = None
+    # batchtime: Optional[int] = None # DEVPROD-12032
     stepback: Optional[bool] = None
 
     def get_task_ref(self, distros: Optional[List[str]] = None) -> EvgTaskRef:

--- a/tests/shrub/v3/test_evg_task.py
+++ b/tests/shrub/v3/test_evg_task.py
@@ -150,10 +150,11 @@ class TestTaskFields:
         _test_task_field("patchable", False, ["patchable: false"])
         _test_task_field("patchable", True, ["patchable: true"])
 
-    def test_task_batchtime(self):
-        _test_task_field("batchtime", None, None)
-        _test_task_field("batchtime", 0, ["batchtime: 0"])
-        _test_task_field("batchtime", 123, ["batchtime: 123"])
+    # DEVPROD-12032
+    # def test_task_batchtime(self):
+    #     _test_task_field("batchtime", None, None)
+    #     _test_task_field("batchtime", 0, ["batchtime: 0"])
+    #     _test_task_field("batchtime", 123, ["batchtime: 123"])
 
     def test_task_stepback(self):
         _test_task_field("stepback", None, None)


### PR DESCRIPTION
Partially reverts https://github.com/evergreen-ci/shrub.py/pull/37 due to [DEVPROD-11988](https://jira.mongodb.org/browse/DEVPROD-11988) and [DEVPROD-12032](https://jira.mongodb.org/browse/DEVPROD-12032) clarifying that task-level `batchtime` is not actually supported at the moment.

```
WARNING: strict unmarshalling YAML: load project error(s): loading file '[...]': error unmarshalling yaml strict: yaml: unmarshal errors:
  line [...]: field batchtime not found in type model.parserTask
```

At the moment, `batchtime` is only supported for task definitions within a build variant definition, not for standalone task definitions. I expect this feature will eventually be implemented, so the relevant code blocks are simply commented out for now with a reference to [DEVPROD-12032](https://jira.mongodb.org/browse/DEVPROD-12032); please indicate if removal is preferred instead.