### PR TITLE
Add `batchtime` and `depends_on` to `shrub.v3.evg_task.EvgTaskRef`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.5.0 - 2024-11-12
+- Add `batchtime` and `depends_on` fields to `shrub.v3.evg_task.EvgTaskRef`.
+
 ## 3.4.0 - 2024-10-30
 - Added additional `*_can_fail_task` and `*_timeout_secs` fields to `shrub.v3.evg_task_group.EvgTaskGroup`.
 - Restrict the type of `*_timeout_secs` fields to `Optional[int]` instead of `Optional[Union[int, str]]`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "shrub.py"
-version = "3.4.0"
+version = "3.5.0"
 description = "Library for creating evergreen configurations"
 authors = ["DevProd Services & Integrations Team <devprod-si-team@mongodb.com>"]
 license = "Apache-2.0"

--- a/src/shrub/v3/evg_task.py
+++ b/src/shrub/v3/evg_task.py
@@ -24,10 +24,14 @@ class EvgTaskRef(BaseModel):
 
     * name: Name of task.
     * distros: Distro that task should be run on.
+    * depends_on: Other tasks that must be successful for this task to run.
+    * batchtime: How frequent this task should be run.
     """
 
     name: str
     distros: Optional[List[str]] = None
+    depends_on: Optional[List[EvgTaskDependency]] = None
+    batchtime: Optional[int] = None
 
 
 class EvgTask(BaseModel):


### PR DESCRIPTION
Followup to https://github.com/evergreen-ci/shrub.py/pull/37 and https://github.com/evergreen-ci/shrub.py/pull/40, which attempted to add `batchtime` for task definitions but reverted the changes due to `batchtime` currently only being supported in task references under a build variant definition. This PR adds support for said `batchtime` in task references as a new field in `EvgTaskRef`.

The `depends_on` field is a drive-by inclusion. It seems like there are more fields which could be added (e.g. `activate`, `cron`, etc.), but these are excluded for now as they are not yet present in `EvgTask`.

The `EvgTask.get_task_ref()` function is deliberately _not_ updated to support the additional fields (which currently only supports `distros` (which should probably be renamed to `run_on`)), as imo its primary function is to ensure consistency with the name of the task from which the reference is created. To support extension of task reference fields, it may be worth changing its parameter list to `(self, **kwargs)` and simply forward `**kwargs` to the `EvgTaskRef` object's constructor.