### PR TITLE
Update perf_send fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 3.10.0 - 2025-04-09
+## 3.10.0 - 2025-04-10
 - Relax field requirements in ``perf_send``.
 
 ## 3.9.0 - 2025-04-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 3.10.0 - 2025-04-08
+## 3.10.0 - 2025-04-09
 - Relax field requirements in ``perf_send``.
 
 ## 3.9.0 - 2025-04-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.10.0 - 2025-04-08
+- Relax field requirements in ``perf_send``.
+
 ## 3.9.0 - 2025-04-02
 - Add support for ``aws_session_token`` in s3 commands.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "shrub.py"
-version = "3.9.0"
+version = "3.10.0"
 description = "Library for creating evergreen configurations"
 authors = ["DevProd Services & Integrations Team <devprod-si-team@mongodb.com>"]
 license = "Apache-2.0"

--- a/src/shrub/v3/evg_command.py
+++ b/src/shrub/v3/evg_command.py
@@ -670,10 +670,10 @@ def key_val_inc(
 
 def perf_send(
     file: str,
-    aws_key: str,
-    aws_secret: str,
-    bucket: str,
-    prefix: str,
+    aws_key: Optional[str] = None,
+    aws_secret: Optional[str] = None,
+    bucket: Optional[str] = None,
+    prefix: Optional[str] = None,
     region: Optional[str] = None,
     command_type: Optional[EvgCommandType] = None,
 ) -> BuiltInCommand:


### PR DESCRIPTION
All of the fields in `perf_send` should be optional except for`file`: https://github.com/evergreen-ci/shrub/blob/a31f72b82851191db6726ee38d63dcf1d07b5047/operations.go#L559.

After this change, mongo-python-driver will be fully converted to using `shrub.py`!